### PR TITLE
Fix with Thaumcraft 4.2.2.B6

### DIFF
--- a/src/main/java/flaxbeard/thaumicexploration/block/BlockThinkTank.java
+++ b/src/main/java/flaxbeard/thaumicexploration/block/BlockThinkTank.java
@@ -18,11 +18,11 @@ import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
-import thaumcraft.common.blocks.JarStepSound;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import flaxbeard.thaumicexploration.ThaumicExploration;
 import flaxbeard.thaumicexploration.tile.TileEntityThinkTank;
+import thaumcraft.common.blocks.CustomStepSound;
 
 public class BlockThinkTank extends BlockContainer
 {
@@ -48,7 +48,7 @@ public class BlockThinkTank extends BlockContainer
     {
         super(Material.glass);
         this.isActive = par2;
-        setStepSound(new JarStepSound("jar", 1.0F, 1.0F));
+        setStepSound(new CustomStepSound("jar", 1.0F, 1.0F));
         setHardness(0.3F);
         setLightLevel(0.66F);
     }


### PR DESCRIPTION
The Think Tank was using a class removed in Thaumcraft 4.2.2.B6 (or maybe B5), resulting in NoClassDefFoundError, by changing two lines of code, it now works with the latest beta build.
