### PR TITLE
Fixed 'Everfull Urn' bug

### DIFF
--- a/src/main/java/flaxbeard/thaumicexploration/block/BlockEverfullUrn.java
+++ b/src/main/java/flaxbeard/thaumicexploration/block/BlockEverfullUrn.java
@@ -126,31 +126,25 @@ public class BlockEverfullUrn extends BlockContainer {
     
     public boolean onBlockActivated(World world, int par2, int par3, int par4, EntityPlayer entityPlayer, int par6, float par7, float par8, float par9)
     {
-
-		
-			if (entityPlayer.inventory.getCurrentItem() != null){ 
-				if (entityPlayer.inventory.getCurrentItem().getItem() == Items.bucket) {
+    		ItemStack curItem = entityPlayer.inventory.getCurrentItem();
+			if (curItem != null){ 
+				if (curItem.getItem() == Items.bucket) {
 					entityPlayer.inventory.decrStackSize(entityPlayer.inventory.currentItem, 1);
 					if (!entityPlayer.inventory.addItemStackToInventory(new ItemStack(Items.water_bucket, 1))) {
 						entityPlayer.dropItem(Items.water_bucket, 1);
 					}
 		            world.playSoundAtEntity(entityPlayer, "liquid.swim", 0.5F, 1.0F);
 				}
-				else if (FluidContainerRegistry.isEmptyContainer(entityPlayer.inventory.getCurrentItem())) {
-					ItemStack newStack = entityPlayer.inventory.getCurrentItem();
+				else if (FluidContainerRegistry.isEmptyContainer(curItem)) {
+					ItemStack newStack = curItem;
 					entityPlayer.inventory.decrStackSize(entityPlayer.inventory.currentItem, 1);
 					if (!entityPlayer.inventory.addItemStackToInventory(FluidContainerRegistry.fillFluidContainer(new FluidStack(FluidRegistry.WATER, 1000), newStack))) {
 						entityPlayer.dropItem(FluidContainerRegistry.fillFluidContainer(new FluidStack(FluidRegistry.WATER, 1000), newStack).getItem(),1);
 					}
 					world.playSoundAtEntity(entityPlayer, "liquid.swim", 0.5F, 1.0F);
 				}
-				else if (entityPlayer.inventory.getCurrentItem().getItem() instanceof IFluidContainerItem) {
-					ItemStack newStack = new ItemStack(entityPlayer.inventory.getCurrentItem().getItem(),1);
-					entityPlayer.inventory.decrStackSize(entityPlayer.inventory.currentItem, 1);
-					((IFluidContainerItem)newStack.getItem()).fill(newStack, new FluidStack(FluidRegistry.WATER, 1000), true);
-					if (!entityPlayer.inventory.addItemStackToInventory(newStack)) {
-						entityPlayer.dropItem(newStack.getItem(),newStack.stackSize);
-					}
+				else if (curItem.getItem() instanceof IFluidContainerItem) {
+					((IFluidContainerItem)curItem.getItem()).fill(curItem, new FluidStack(FluidRegistry.WATER, 1000), true);
 					world.playSoundAtEntity(entityPlayer, "liquid.swim", 0.5F, 1.0F);
 				}
 			}


### PR DESCRIPTION
Everfull Urn will no longer remove damage value from handheld tanks such as Ender Tank and Portable Tanks causing them to convert into other items (Ender Chest and Creative Portable Tank)
